### PR TITLE
Switch jmanus module to MySQL

### DIFF
--- a/spring-ai-alibaba-jmanus/pom.xml
+++ b/spring-ai-alibaba-jmanus/pom.xml
@@ -166,10 +166,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
-        <!-- H2 Database -->
+        <!-- MySQL Database -->
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/spring-ai-alibaba-jmanus/src/main/resources/application.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/application.yml
@@ -13,26 +13,21 @@ spring:
     mcp:
       client:
         enabled: false
-  # H2 database configuration
+  # MySQL database configuration
   datasource:
-    url: jdbc:h2:file:./h2-data/openmanus_db;MODE=MYSQL;DATABASE_TO_LOWER=TRUE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password: $FSD#@!@#!#$!12341234
+    url: jdbc:mysql://localhost:3306/openmanus_db?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=UTC
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: root
   # JPA configuration
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         format_sql: true
-  # H2 console configuration
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
 logging:
   file:
     name: ./logs/info.log


### PR DESCRIPTION
## Summary
- replace H2 runtime with MySQL driver in `spring-ai-alibaba-jmanus`
- update `application.yml` to use a MySQL datasource and remove H2 console

## Testing
- `./mvnw -q -pl spring-ai-alibaba-jmanus -am test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6861fa19218c8328a8db44b2e4bc0f06